### PR TITLE
UserDefaultsの監視

### DIFF
--- a/GameClock/Main/MainViewController.swift
+++ b/GameClock/Main/MainViewController.swift
@@ -22,28 +22,23 @@ class MainViewController: UIViewController {
     
     var player: AVAudioPlayer?
     var timer = Timer()
-    var observer: NSKeyValueObservation?
     var count = 0
     var nowTurn: Player = .P1
-    var timerValue = 0
     var totalSec = 0
+    var stringRemainCount = "0"
+    var observer: NSKeyValueObservation?
     
     let settings = UserDefaults.standard
-    let p1TimeKey = "p1_time"
-    let p2TimeKey = "p2_time"
-    
+    let p1TimeKey = "p1TimeKey"
+    let p2TimeKey = "p2TimeKey"
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
         p2ButtonLabel.transform = flipUpsideDown()
-        
-        observer = settings.observe(\.hour, options: [.initial, .new], changeHandler: { [weak self] (defaults, change) in
-            print(UserDefaults.standard.integer(forKey: "hour"))
-        })
-        
-        observer = settings.observe(\.min, options: [.initial, .new], changeHandler: { [weak self] (defaults, change) in
-            print(UserDefaults.standard.integer(forKey: "min"))
+        settings.register(defaults: [p1TimeKey : 0])
+        observer = UserDefaults.standard.observe(\.p1Time, options: [.initial, .new], changeHandler: { [weak self] (defaults, change) in
+            _ = self!.displayUpdate()
         })
     }
     
@@ -69,11 +64,13 @@ class MainViewController: UIViewController {
     
     @IBAction func p1ButtonPressed(_ sender: UIButton) {
         nowTurn = .P2
+        totalSec = settings.integer(forKey: p1TimeKey)
         playerButtonPressed(nowTurn: p2ButtonLabel, restTurn: p1ButtonLabel)
     }
     
     @IBAction func p2ButtonPressed(_ sender: UIButton) {
         nowTurn = .P1
+        totalSec = settings.integer(forKey: p1TimeKey)
         playerButtonPressed(nowTurn: p1ButtonLabel, restTurn: p2ButtonLabel)
     }
     
@@ -98,12 +95,8 @@ class MainViewController: UIViewController {
     }
     
     func displayUpdate() -> Int {
-        
         let remainCount = totalSec - count
-        let hour = String(remainCount / 3600)
-        let min = String(remainCount % 3600 / 60)
-        let sec = String(remainCount % 3600 % 60)
-        let stringRemainCount = "\(hour):\(min):\(sec)"
+        convertHMS(time: remainCount)
         
         switch nowTurn {
         case .P1:
@@ -128,22 +121,27 @@ class MainViewController: UIViewController {
         return flipUpsideDown
     }
     
-    func totalSecConversion() {
-        let hour = settings.integer(forKey: "hour")
-        let min = settings.integer(forKey: "min")
-        let sec = settings.integer(forKey: "sec")
-        totalSec = hour * 60 * 60 + min * 60 + sec
+    func convertHMS(time: Int) {
+        let hour = time / 3600
+        let min = time % 3600 / 60
+        let sec = time % 3600 % 60
+        
+        let stringHour = String(hour)
+        let stringMin = String(format: "%02d", min)
+        let stringSec = String(format: "%02d", sec)
+        
+        if hour > 0 {
+            stringRemainCount = "\(stringHour):\(stringMin):\(stringSec)"
+        } else if hour <= 0 {
+            stringRemainCount = "\(stringMin):\(stringSec)"
+        } else if min <= 0 {
+            stringRemainCount = "\(stringSec)"
+        }
     }
 }
 
 extension UserDefaults {
-    @objc dynamic var hour: Int {
-        return integer(forKey: "hour")
-    }
-    @objc dynamic var min: Int {
-        return integer(forKey: "min")
-    }
-    @objc dynamic var sec: Int {
-        return integer(forKey: "sec")
+    @objc dynamic var p1Time: Int {
+        return integer(forKey: "p1TimeKey")
     }
 }

--- a/GameClock/Settings/P1PickerViewController.swift
+++ b/GameClock/Settings/P1PickerViewController.swift
@@ -13,7 +13,7 @@ class P1PickerViewController: UIViewController, UIPickerViewDelegate, UIPickerVi
     
     let dataList = [[Int](0...10), [Int](0...60), [Int](0...60)]
     let settings = UserDefaults.standard
-    let p1TimeKey = "p1_time"
+    let p1TimeKey = "p1TimeKey"
     
     var hour = 0
     var min = 0
@@ -22,17 +22,8 @@ class P1PickerViewController: UIViewController, UIPickerViewDelegate, UIPickerVi
     
     override func viewDidLoad() {
         super.viewDidLoad()
-//        let timerValue = settings.integer(forKey: p1TimeKey)
-        settings.register(defaults: ["hour": 0])
-        settings.register(defaults: ["min": 0])
-        settings.register(defaults: ["sec": 0])
         p1PickerView.delegate = self
         p1PickerView.dataSource = self
-        //        for row in 0..<dataList.count {
-        //            if dataList[row] == timerValue {
-        //                p1PickerView.selectRow(row, inComponent: 0, animated: true)
-        //            }
-        //        }
     }
     
     func numberOfComponents(in pickerView: UIPickerView) -> Int {
@@ -52,20 +43,16 @@ class P1PickerViewController: UIViewController, UIPickerViewDelegate, UIPickerVi
         switch component {
         case 0:
             hour = row
-            settings.setValue(hour, forKey: "hour")
-            settings.synchronize()
-            
         case 1:
             min = row
-            settings.setValue(min, forKey: "min")
-            settings.synchronize()
-            
         case 2:
             sec = row
-            settings.setValue(sec, forKey: "sec")
-            settings.synchronize()
         default:
             print("pickerでエラー")
         }
+        
+        totalSec = hour * 60 * 60 + min * 60 + sec
+        settings.setValue(totalSec, forKey: p1TimeKey)
+        settings.synchronize()
     }
 }


### PR DESCRIPTION
- `UserDefaults`を変更したときの監視ができるようになったのでそのチェック
- ピッカーで時間変更し、メイン画面に戻ってきた時に設定した時間で表示されているようにしたいのですがそれができないので、どうすればよいかアドバイスいただきたいです…
（時間自体は変更されていて、タップするとその時間で表示されタイマーが作動する。
タップするまでは直前に使用していた画面のままになっている。）
