### PR TITLE
SettingsVCのrightDetailを更新

### DIFF
--- a/GameClock/Settings/SettingsViewController.swift
+++ b/GameClock/Settings/SettingsViewController.swift
@@ -10,12 +10,26 @@ import UIKit
 class SettingsViewController: UITableViewController {
     
     var settings: [Setting] = []
+    var observedP1: NSKeyValueObservation?
+    var observedP2: NSKeyValueObservation?
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
         self.navigationController?.navigationBar.tintColor = .gray
         loadData()
+        
+        observedP1 = userDefaults.observe(\.p1TimeKey, options: [.initial, .new], changeHandler: { [weak self] (defaults, change) in
+            let newValue = change.newValue!
+            self!.settings[0] = Setting(item: "Player 1", rightDetail: convertHMS(newValue))
+            print(self!.settings[0].self.rightDetail)
+        })
+        
+        observedP2 = userDefaults.observe(\.p2TimeKey, options: [.initial, .new], changeHandler: { [weak self] (defaults, change) in
+            let newValue = change.newValue!
+            self!.settings[1] = Setting(item: "Player 2", rightDetail: convertHMS(newValue))
+            print(self!.settings[1].self.rightDetail)
+        })
     }
 
     @IBAction func doneButtonPressed(_ sender: UIButton) {
@@ -29,7 +43,7 @@ class SettingsViewController: UITableViewController {
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return settings.count
     }
-    
+
     func loadData() {
         let p1Time = userDefaults.integer(forKey: p1TimeKey)
         let p2Time = userDefaults.integer(forKey: p2TimeKey)

--- a/GameClock/Settings/SettingsViewController.swift
+++ b/GameClock/Settings/SettingsViewController.swift
@@ -22,13 +22,13 @@ class SettingsViewController: UITableViewController {
         observedP1 = userDefaults.observe(\.p1TimeKey, options: [.initial, .new], changeHandler: { [weak self] (defaults, change) in
             let newValue = change.newValue!
             self!.settings[0] = Setting(item: "Player 1", rightDetail: convertHMS(newValue))
-            print(self!.settings[0].self.rightDetail)
+            self!.tableView.reloadData()
         })
         
         observedP2 = userDefaults.observe(\.p2TimeKey, options: [.initial, .new], changeHandler: { [weak self] (defaults, change) in
             let newValue = change.newValue!
             self!.settings[1] = Setting(item: "Player 2", rightDetail: convertHMS(newValue))
-            print(self!.settings[1].self.rightDetail)
+            self!.tableView.reloadData()
         })
     }
 


### PR DESCRIPTION
設定一覧内、プレイヤーの設定時間を表示している部分をピッカーが変更されたときに更新したいのですが、やり方がわかりませんでした。。。
- ピッカー変更後モーダルを閉じ、再び設定を開くと更新されている
- ピッカー変更後`<Back`ボタンで戻ると更新されていない
以上の事から`<Back`ボタンではひとつ前の画面（変更前の状態）に戻るだけなのか…？と推測しましたが、以降糸口が見つからずに手詰まってます。
多分しょうもない事なのかなとは思いますがご教示くださいますようお願いします…